### PR TITLE
feat(eightqueens): migrate console app and tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     
     <!-- UI -->
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc4.5" />

--- a/DotNetLearningLab.slnx
+++ b/DotNetLearningLab.slnx
@@ -1,5 +1,9 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Chess/Chess.csproj" />
+    <Project Path="src/EightQueens/EightQueens.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/EightQueens.Tests/EightQueens.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/EightQueens/EightQueens.csproj
+++ b/src/EightQueens/EightQueens.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chess\Chess.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/EightQueens/Program.cs
+++ b/src/EightQueens/Program.cs
@@ -1,0 +1,21 @@
+﻿// See https://aka.ms/new-console-template for more information
+using DotNetLearningLab.Chess;
+
+Console.WriteLine("Eight Queens Puzzle - .NET 10 Migration");
+Console.WriteLine("Finding solutions...");
+
+var solutions = new List<ChessBoard>();
+ChessBoard.PlaceQueens(solutions);
+if (solutions.Count > 0)
+{
+    Console.WriteLine($"Found {solutions.Count} solutions.");
+    if (solutions.Count > 0)
+    {
+        Console.WriteLine("First solution:");
+        Console.WriteLine(solutions[0].ToString());
+    }
+}
+else
+{
+    Console.WriteLine("No solutions found.");
+}

--- a/tests/EightQueens.Tests/ChessBoardTests.cs
+++ b/tests/EightQueens.Tests/ChessBoardTests.cs
@@ -1,0 +1,63 @@
+using DotNetLearningLab.Chess;
+using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EightQueens.Tests
+{
+    public class ChessBoardTests
+    {
+        [Fact]
+        public void Test_010_EmptyBoardIsSafe()
+        {
+            var board = new ChessBoard("00000000");
+
+            Assert.True(board.IsSafe());
+        }
+
+        [Fact]
+        public void Test_011_BoardIsSafe()
+        {
+            var board = new ChessBoard("10000000");
+
+            Assert.True(board.IsSafe());
+        }
+
+        [Fact]
+        public void Test_012_BoardIsSafe()
+        {
+            var board = new ChessBoard("15863720");
+
+            Assert.True(board.IsSafe());
+        }
+
+        [Fact]
+        public void Test_019_EachKnownSolutionIsSafe()
+        {
+            var boards = from solution in ChessBoard.Solutions
+                         select new ChessBoard(solution);
+
+            // checks the validity of each known solution
+            Assert.True(boards.All(board => board.IsSafe()));
+        }
+
+        [Fact]
+        public void Test_020_PlaceQueens()
+        {
+            // starting from an empty board, can we find one solution
+            Assert.True(ChessBoard.PlaceQueens());
+        }
+
+        [Fact]
+        public void Test_030_PlaceQueens()
+        {
+            // starting from an empty board, can we find all solutions
+            var solutions = new List<ChessBoard>(92);
+            ChessBoard.PlaceQueens(solutions);
+            Assert.Equal(92, solutions.Count);
+
+            // confirm all found solutions are known
+            Assert.True(solutions.All(board => ChessBoard.Solutions.Contains(board.ToString())));
+        }
+    }
+}

--- a/tests/EightQueens.Tests/EightQueens.Tests.csproj
+++ b/tests/EightQueens.Tests/EightQueens.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Chess\Chess.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Migrated `EightQueens` console application and unit tests to .NET 10.

## Changes
- Created `src/EightQueens` (Console App) demonstrating usage of `Chess` library.
- Created `tests/EightQueens.Tests` (xUnit) ensuring logic correctness.
- Migrated legacy `Tests_Chess.cs` to xUnit format.
- Verified 92 solutions found.

## Verifiction
- `dotnet test` passed (6 tests).
- `dotnet run` output: "Found 92 solutions."

Closes #5
