### PR TITLE
feat(musical): migrate to net10-winforms and NAudio

### DIFF
--- a/DotNetLearningLab.slnx
+++ b/DotNetLearningLab.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/Chess/Chess.csproj" />
     <Project Path="src/EightQueens/EightQueens.csproj" />
     <Project Path="src/GeoLocator/GeoLocator.csproj" />
+    <Project Path="src/MusicalInstrument/MusicalInstrument.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/EightQueens.Tests/EightQueens.Tests.csproj" />

--- a/src/MusicalInstrument/Form1.Designer.cs
+++ b/src/MusicalInstrument/Form1.Designer.cs
@@ -1,0 +1,98 @@
+﻿namespace MusicalInstrument
+{
+    partial class Form1
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.trackVolume = new System.Windows.Forms.TrackBar();
+            this.trackFrequency = new System.Windows.Forms.TrackBar();
+            this.panel = new System.Windows.Forms.Panel();
+            ((System.ComponentModel.ISupportInitialize)(this.trackVolume)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackFrequency)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // trackVolume
+            // 
+            this.trackVolume.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackVolume.Location = new System.Drawing.Point(12, 369);
+            this.trackVolume.Maximum = 100;
+            this.trackVolume.Name = "trackVolume";
+            this.trackVolume.Size = new System.Drawing.Size(776, 69);
+            this.trackVolume.TabIndex = 0;
+            this.trackVolume.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TheMouseDown);
+            this.trackVolume.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TheMouseUp);
+            // 
+            // trackFrequency
+            // 
+            this.trackFrequency.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackFrequency.Location = new System.Drawing.Point(719, 12);
+            this.trackFrequency.Maximum = 1000;
+            this.trackFrequency.Minimum = 100;
+            this.trackFrequency.Name = "trackFrequency";
+            this.trackFrequency.Orientation = System.Windows.Forms.Orientation.Vertical;
+            this.trackFrequency.Size = new System.Drawing.Size(69, 351);
+            this.trackFrequency.TabIndex = 1;
+            this.trackFrequency.Value = 100;
+            this.trackFrequency.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TheMouseDown);
+            this.trackFrequency.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TheMouseUp);
+            // 
+            // panel
+            // 
+            this.panel.Location = new System.Drawing.Point(12, 12);
+            this.panel.Name = "panel";
+            this.panel.Size = new System.Drawing.Size(701, 351);
+            this.panel.TabIndex = 2;
+            this.panel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TheMouseDown);
+            this.panel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.panel_MouseMove);
+            this.panel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TheMouseUp);
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.panel);
+            this.Controls.Add(this.trackFrequency);
+            this.Controls.Add(this.trackVolume);
+            this.Name = "Form1";
+            this.Text = "Musical Instrument (Net10)";
+            ((System.ComponentModel.ISupportInitialize)(this.trackVolume)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackFrequency)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TrackBar trackVolume;
+        private System.Windows.Forms.TrackBar trackFrequency;
+        private System.Windows.Forms.Panel panel;
+    }
+}

--- a/src/MusicalInstrument/Form1.cs
+++ b/src/MusicalInstrument/Form1.cs
@@ -1,0 +1,90 @@
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using System.Windows.Forms;
+using System.Drawing;
+using System;
+
+namespace MusicalInstrument
+{
+    public partial class Form1 : Form
+    {
+        SignalGenerator sine = new SignalGenerator()
+        {
+            Type = SignalGeneratorType.Sin,
+            Gain = 0.2,
+        };
+
+        WaveOutEvent player = new WaveOutEvent();
+
+        public Form1()
+        {
+            InitializeComponent();
+
+            try 
+            {
+                player.Init(sine);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error initializing audio: {ex.Message}");
+            }
+
+            trackFrequency.ValueChanged += (s, e) => sine.Frequency = trackFrequency.Value;
+            trackFrequency.Value = 600;
+
+            trackVolume.ValueChanged += (s, e) => player.Volume = trackVolume.Value / 100F;
+            trackVolume.Value = 50;
+
+            // Form closing event to stop player
+            this.FormClosing += (s, e) => 
+            {
+                player.Stop();
+                player.Dispose();
+            };
+        }
+
+        private Point cursorPoritionOnMouseDown;
+        private bool ButtonIsDown = false;
+        private void TheMouseDown(object sender, MouseEventArgs e)
+        {
+            try
+            {
+                player.Play();
+            }
+            catch (Exception ex)
+            {
+                // Ignore if audio device fails, just log to console
+                Console.WriteLine($"Audio Error: {ex.Message}");
+            }
+
+            cursorPoritionOnMouseDown = e.Location;
+            ButtonIsDown = true;
+        }
+
+        private void TheMouseUp(object sender, MouseEventArgs e)
+        {
+            player.Stop();
+            ButtonIsDown = false;
+        }
+
+        private void panel_MouseMove(object sender, MouseEventArgs e)
+        {
+            var dX = cursorPoritionOnMouseDown.X - e.X;
+            var dY = cursorPoritionOnMouseDown.Y - e.Y;
+
+            var vol = player.Volume - (dX / 100000f);
+            var freq = sine.Frequency + (dY / 10f);
+
+            if (ButtonIsDown)
+            {
+                player.Volume = (vol > 0) ? (vol < 1) ? vol : 1 : 0;
+                sine.Frequency = (freq > 100) ? (freq < 1000) ? freq : 1000 : 100;
+
+                trackFrequency.Value = (int)Math.Round(sine.Frequency);
+                trackVolume.Value = (int)Math.Round(player.Volume * 100);
+            }
+
+            Text = $"Musical Instrument! ({dX}, {dY}), ({vol}, {freq})";
+        }
+    }
+}

--- a/src/MusicalInstrument/MusicalInstrument.csproj
+++ b/src/MusicalInstrument/MusicalInstrument.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NAudio" />
+  </ItemGroup>
+
+</Project>

--- a/src/MusicalInstrument/Program.cs
+++ b/src/MusicalInstrument/Program.cs
@@ -1,0 +1,16 @@
+namespace MusicalInstrument;
+
+static class Program
+{
+    /// <summary>
+    ///  The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    static void Main()
+    {
+        // To customize application configuration such as set high DPI settings or default font,
+        // see https://aka.ms/applicationconfiguration.
+        ApplicationConfiguration.Initialize();
+        Application.Run(new Form1());
+    }    
+}


### PR DESCRIPTION
## Summary
Migrated `MusicalInstrument` WinForms application to .NET 10.
The application uses **NAudio** to generate sound waves (Sine Wave) controlled by mouse position on a panel.

## Changes
- Created `src/MusicalInstrument/MusicalInstrument.csproj` (WinForms, `net10.0-windows`).
- Added package `NAudio`.
- Migrated `Form1.cs` logic:
  - Generates Sine Wave using `SignalGenerator`.
  - Controls Frequency (Mouse Y) and Volume (Mouse X inv).
  - Handles Mouse Down/Up/Move events.
- Migrated `Form1.Designer.cs`:
  - Defined Layout with `Panel` and 2 `TrackBars`.

## Verification
- Local Build: **PASS**.
- Logic: `try-catch` blocks added around Audio initialization/playback to prevent crashes if no audio device is present (important for CI).

Closes #9
