### PR TITLE
chore(gitignore): clean up entries for current project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,5 @@ obj/
 Thumbs.db
 .DS_Store
 
-# Legacy Migration (Ignored per user request - local only)
-old_projects_migration/
-
-# Workflow (Ignored per user request)
-.workflow/
+# Local config
+.agent/


### PR DESCRIPTION
## What

Clean up `.gitignore` to reflect the current project structure after completing the migration phase.

Closes #23

## Changes

- Removed `.workflow/` entry (directory no longer exists)
- Removed `old_projects_migration/` entry (migration completed, directory removed)
- Added `.agent/` entry for local development config
- Updated comments to match current structure

## Testing

- [x] Verified only `.gitignore` is modified
- [x] No untracked files appear after the change
