### PR TITLE
fix: WeatherTrend path resolution in single-file builds

### DIFF
--- a/src/WeatherTrend/MainWindow.xaml.cs
+++ b/src/WeatherTrend/MainWindow.xaml.cs
@@ -12,8 +12,12 @@ namespace DotNetLearningLab.WeatherTrend
 {
     public partial class MainWindow : Window
     {
-        // Use AppContext.BaseDirectory for reliable path resolution in .NET Core+
-        private static string filename = Path.Combine(AppContext.BaseDirectory, "pond_data", "Environmental_Data_Deep_Moor_2012.txt");
+        // Use Environment.ProcessPath to resolve the actual .exe location on disk
+        // AppContext.BaseDirectory points to the temp extraction folder in single-file builds
+        private static string filename = Path.Combine(
+            Path.GetDirectoryName(Environment.ProcessPath)!,
+            "pond_data",
+            "Environmental_Data_Deep_Moor_2012.txt");
 
         public MainWindow()
         {


### PR DESCRIPTION
## Summary

Fix `WeatherTrend` startup crash in single-file demo builds.

## Root Cause

`AppContext.BaseDirectory` resolves to a **temp extraction folder** in single-file `.exe` builds, not the actual `.exe` location. The `pond_data` directory sits next to the `.exe` on disk but was being searched for in the wrong location.

## Fix

Switched to `Environment.ProcessPath` (.NET 6+), which correctly returns the actual executable path on disk.

## Verification

- Published locally with `dotnet publish -p:PublishSingleFile=true`.
- Confirmed `pond_data` exists in publish output directory.
- Confirmed `WeatherTrend.exe` launches without crash.

## Related Issue

Closes #40
