### PR TITLE
fix: include companion files in demo release zips

### DIFF
--- a/.github/workflows/release_demos.yml
+++ b/.github/workflows/release_demos.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Zip Executable
         shell: pwsh
         run: |
-          $source = "release/${{ matrix.app }}/${{ matrix.app }}.exe"
+          $source = "release/${{ matrix.app }}/*"
           $destination = "release/${{ matrix.app }}-Demo.zip"
           Compress-Archive -Path $source -DestinationPath $destination
           Write-Host "Created $destination"


### PR DESCRIPTION
## Summary

Fix `WeatherTrend-Demo.zip` to include the `pond_data` directory alongside the `.exe`.

## Root Cause

The "Zip Executable" step in `release_demos.yml` only archived the `.exe` file, ignoring companion files like `pond_data/` that are excluded from single-file bundling but required at runtime.

## Fix

Changed the zip source from the single `.exe` to the entire publish output folder (`/*`), ensuring all companion files are included.

## Related Issue

Closes #44
