### PR TITLE
chore(docs): clean up stale links in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 ## Documentation
 
 - See [ARCHITECTURE.md](ARCHITECTURE.md) for solution structure.
-- See [impl_plan.md](.gemini/antigravity/brain/c8fd0eb8-d5a7-494e-a947-5e81f6775bc7/implementation_plan.md) if available for roadmap.
+- See the project's [GitHub Issues](https://github.com/millenniumsingha/dotnet-learning-lab/issues) for the roadmap.
 
 ## Style Guide
 


### PR DESCRIPTION
## What

Replaces a stale internal path link in `CONTRIBUTING.md` with a working link to the project's GitHub Issues page.

Closes #48

## Changes

- [MODIFY] `CONTRIBUTING.md`: Replaced `.gemini/...` link with `https://github.com/millenniumsingha/dotnet-learning-lab/issues`

## Testing

- [x] Manual verification: Link points to valid URL
