### PR TITLE
chore(build): fix Directory.Build.props and CA errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 ## Documentation
 
 - See [ARCHITECTURE.md](ARCHITECTURE.md) for solution structure.
-- See [impl_plan.md](.gemini/antigravity/brain/c8fd0eb8-d5a7-494e-a947-5e81f6775bc7/implementation_plan.md) if available for roadmap.
+- See the project's [GitHub Issues](https://github.com/millenniumsingha/dotnet-learning-lab/issues) for the roadmap.
 
 ## Style Guide
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnrollInPreviewFeatures>true</EnrollInPreviewFeatures>
+    <!-- Audit Fix: Enforce code style and analysis -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>

--- a/src/GeoLocator/MapImage.cs
+++ b/src/GeoLocator/MapImage.cs
@@ -7,7 +7,7 @@ using Windows.Devices.Geolocation;
 
 namespace DotNetLearningLab.GeoLocator
 {
-    class MapImage
+    sealed class MapImage
     {
         private static readonly HttpClient _httpClient = new HttpClient();
 
@@ -17,7 +17,7 @@ namespace DotNetLearningLab.GeoLocator
             var lon = coordinate.Point.Position.Longitude;
             var accuracy = coordinate.Accuracy;
 
-            string filename = $"{lat:00.000},{lon:00.000},{accuracy:0000}m.jpg";
+            string filename = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:00.000},{1:00.000},{2:0000}m.jpg", lat, lon, accuracy);
             
             // Sanitize filename
             filename = filename.Replace("/", "_").Replace(":", "_");
@@ -57,7 +57,7 @@ namespace DotNetLearningLab.GeoLocator
         {
             // Replaced deprecated HERE Maps API with placeholder service
             // This demonstrates network functionality without requiring new API keys
-            string text = $"Lat: {lat:F3}\nLon: {lon:F3}\nAcc: {accuracy:F0}m";
+            string text = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Lat: {0:F3}\nLon: {1:F3}\nAcc: {2:F0}m", lat, lon, accuracy);
             string encodedText = Uri.EscapeDataString(text);
             
             return new Uri($"https://placehold.co/600x400/png?text={encodedText}");

--- a/src/GeoLocator/Program.cs
+++ b/src/GeoLocator/Program.cs
@@ -4,7 +4,7 @@ using Windows.Devices.Geolocation;
 
 namespace DotNetLearningLab.GeoLocator
 {
-    class Program
+    sealed class Program
     {
         static async Task Main(string[] args)
         {

--- a/src/MusicalInstrument/Form1.cs
+++ b/src/MusicalInstrument/Form1.cs
@@ -44,7 +44,7 @@ namespace MusicalInstrument
         }
 
         private Point cursorPoritionOnMouseDown;
-        private bool ButtonIsDown = false;
+        private bool ButtonIsDown;
         private void TheMouseDown(object sender, MouseEventArgs e)
         {
             try

--- a/src/WeatherTrend/MainWindow.xaml
+++ b/src/WeatherTrend/MainWindow.xaml
@@ -10,10 +10,10 @@
     <Grid>
         <lvc:CartesianChart Series="{Binding MySeriesCollection}">
             <lvc:CartesianChart.AxisX>
-                <lvc:Axis LabelFormatter="{Binding X_Label_Formatter}"/>
+                <lvc:Axis LabelFormatter="{Binding XLabelFormatter}"/>
             </lvc:CartesianChart.AxisX>
             <lvc:CartesianChart.AxisY>
-                <lvc:Axis LabelFormatter="{Binding Y_Label_Formatter}"/>
+                <lvc:Axis LabelFormatter="{Binding YLabelFormatter}"/>
             </lvc:CartesianChart.AxisY>
         </lvc:CartesianChart>
     </Grid>

--- a/src/WeatherTrend/MainWindow.xaml.cs
+++ b/src/WeatherTrend/MainWindow.xaml.cs
@@ -41,8 +41,8 @@ namespace DotNetLearningLab.WeatherTrend
 
             // Mapping Functions from raw values to doubles for Axis (X & Y)
             var woXY = Mappers.Xy<WeatherObservation>();
-            woXY.X((wo) => wo.TimeStamp.Ticks);
-            woXY.Y((wo) => wo.Barometric_Pressure);
+            woXY.X((wo) => wo.Timestamp.Ticks);
+            woXY.Y((wo) => wo.BarometricPressure);
 
             // Series Collection containing the LineSeries
             MySeriesCollection = new SeriesCollection(woXY)
@@ -55,8 +55,8 @@ namespace DotNetLearningLab.WeatherTrend
 
         private static void LoadData(ChartValues<WeatherObservation> values)
         {
-            var start = DateTime.Parse("2012-01-02 00:00:00");
-            var end = DateTime.Parse("2012-01-02 17:00:00");
+            var start = DateTime.Parse("2012-01-02 00:00:00", System.Globalization.CultureInfo.InvariantCulture);
+            var end = DateTime.Parse("2012-01-02 17:00:00", System.Globalization.CultureInfo.InvariantCulture);
 
             using (var text = new StreamReader(filename))
             {
@@ -70,7 +70,7 @@ namespace DotNetLearningLab.WeatherTrend
 
         public SeriesCollection MySeriesCollection { get; set; }
 
-        public Func<double, string> X_Label_Formatter => (d) => (new DateTime((long)d)).ToString("yyyy-MM:dd HH:mm:ss");
-        public Func<double, string> Y_Label_Formatter => (d) => d.ToString("###.00");
+        public static Func<double, string> XLabelFormatter => (d) => (new DateTime((long)d)).ToString("yyyy-MM:dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+        public static Func<double, string> YLabelFormatter => (d) => d.ToString("###.00", System.Globalization.CultureInfo.InvariantCulture);
     }
 }

--- a/src/WeatherTrend/Models/WeatherData.cs
+++ b/src/WeatherTrend/Models/WeatherData.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+﻿// #nullable disable removed
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,17 +13,17 @@ namespace DotNetLearningLab.WeatherTrend.Models
             TextReader text,
             DateTime? start = null,
             DateTime? end = null,
-            Action<string> errorHandler = null)
+            Action<string>? errorHandler = null)
         {
             return
                 WeatherData.ReadAll(text, errorHandler)
-                .SkipWhile((wo) => wo.TimeStamp < (start ?? DateTime.MinValue))
-                .TakeWhile((wo) => wo.TimeStamp <= (end ?? DateTime.MaxValue));
+                .SkipWhile((wo) => wo.Timestamp < (start ?? DateTime.MinValue))
+                .TakeWhile((wo) => wo.Timestamp <= (end ?? DateTime.MaxValue));
         }
 
-        public static IEnumerable<WeatherObservation> ReadAll(TextReader text, Action<string> errorHandler = null)
+        public static IEnumerable<WeatherObservation> ReadAll(TextReader text, Action<string>? errorHandler = null)
         {
-            string line = null;
+            string? line = null;
 
             while ((line = text.ReadLine()) != null)
             {

--- a/src/WeatherTrend/Models/WeatherObservation.cs
+++ b/src/WeatherTrend/Models/WeatherObservation.cs
@@ -5,8 +5,8 @@ namespace DotNetLearningLab.WeatherTrend.Models
 {
     public struct WeatherObservation
     {
-        public DateTime TimeStamp;
-        public float Barometric_Pressure;
+        public DateTime Timestamp { get; set; }
+        public float BarometricPressure { get; set; }
 
         public static WeatherObservation Parse(string text)
         {
@@ -14,13 +14,13 @@ namespace DotNetLearningLab.WeatherTrend.Models
 
             Debug.Assert(data.Length == 8);
 
-            var timestamp = DateTime.Parse(data[(int)WeatherObservationMetrics.Date_Time].Replace("_", "-"));
-            var pressure = float.Parse(data[(int)WeatherObservationMetrics.Barometric_Pressure]);
+            var timestamp = DateTime.Parse(data[(int)WeatherObservationMetrics.DateTime].Replace("_", "-"), System.Globalization.CultureInfo.InvariantCulture);
+            var pressure = float.Parse(data[(int)WeatherObservationMetrics.BarometricPressure], System.Globalization.CultureInfo.InvariantCulture);
 
             return new WeatherObservation()
             {
-                TimeStamp = timestamp,
-                Barometric_Pressure = pressure
+                Timestamp = timestamp,
+                BarometricPressure = pressure
             };
         }
 
@@ -28,8 +28,8 @@ namespace DotNetLearningLab.WeatherTrend.Models
         {
             wo = new WeatherObservation()
             {
-                TimeStamp = DateTime.MinValue,
-                Barometric_Pressure = float.NaN
+                Timestamp = DateTime.MinValue,
+                BarometricPressure = float.NaN
             };
 
             var data = text.Split('\t');
@@ -37,16 +37,16 @@ namespace DotNetLearningLab.WeatherTrend.Models
             if (data.Length != 8)
                 return false;
 
-            if (!DateTime.TryParse(data[(int)WeatherObservationMetrics.Date_Time].Replace("_", "-"), out DateTime timeStamp))
+            if (!DateTime.TryParse(data[(int)WeatherObservationMetrics.DateTime].Replace("_", "-"), System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out DateTime timeStamp))
                 return false;
 
-            if (!float.TryParse(data[(int)WeatherObservationMetrics.Barometric_Pressure], out float pressure))
+            if (!float.TryParse(data[(int)WeatherObservationMetrics.BarometricPressure], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out float pressure))
                 return false;
 
             wo = new WeatherObservation()
             {
-                TimeStamp = timeStamp,
-                Barometric_Pressure = pressure
+                Timestamp = timeStamp,
+                BarometricPressure = pressure
             };
             return true;
         }

--- a/src/WeatherTrend/Models/WeatherObservationMetrics.cs
+++ b/src/WeatherTrend/Models/WeatherObservationMetrics.cs
@@ -2,13 +2,13 @@
 {
     public enum WeatherObservationMetrics
     {
-        Date_Time,
-        Air_Temp,
-        Barometric_Pressure,
-        Dew_Point,
-        Relative_Humidity,
-        Wind_Dir,
-        Wind_Gust,
-        Wind_Speed
+        DateTime,
+        AirTemp,
+        BarometricPressure,
+        DewPoint,
+        RelativeHumidity,
+        WindDir,
+        WindGust,
+        WindSpeed
     }
 }

--- a/tests/EightQueens.Tests/ChessBoardTests.cs
+++ b/tests/EightQueens.Tests/ChessBoardTests.cs
@@ -8,7 +8,7 @@ namespace EightQueens.Tests
     public class ChessBoardTests
     {
         [Fact]
-        public void Test_010_EmptyBoardIsSafe()
+        public void Test010EmptyBoardIsSafe()
         {
             var board = new ChessBoard("00000000");
 
@@ -16,7 +16,7 @@ namespace EightQueens.Tests
         }
 
         [Fact]
-        public void Test_011_BoardIsSafe()
+        public void Test011BoardIsSafe()
         {
             var board = new ChessBoard("10000000");
 
@@ -24,7 +24,7 @@ namespace EightQueens.Tests
         }
 
         [Fact]
-        public void Test_012_BoardIsSafe()
+        public void Test012BoardIsSafe()
         {
             var board = new ChessBoard("15863720");
 
@@ -32,7 +32,7 @@ namespace EightQueens.Tests
         }
 
         [Fact]
-        public void Test_019_EachKnownSolutionIsSafe()
+        public void Test019EachKnownSolutionIsSafe()
         {
             var boards = from solution in ChessBoard.Solutions
                          select new ChessBoard(solution);
@@ -42,14 +42,14 @@ namespace EightQueens.Tests
         }
 
         [Fact]
-        public void Test_020_PlaceQueens()
+        public void Test020PlaceQueens()
         {
             // starting from an empty board, can we find one solution
             Assert.True(ChessBoard.PlaceQueens());
         }
 
         [Fact]
-        public void Test_030_PlaceQueens()
+        public void Test030PlaceQueens()
         {
             // starting from an empty board, can we find all solutions
             var solutions = new List<ChessBoard>(92);


### PR DESCRIPTION
Fixes #50

## Changes
- Enable `<EnforceCodeStyleInBuild>`
- Set `<AnalysisLevel>` to `latest-recommended`
- Remove invalid `<EnrollInPreviewFeatures>`
- Refactor `WeatherTrend` models to fix `CA1707`, `CA1051`, `CA1305`
- Refactor `ChessBoardTests` to fix `CA1707`
- Add `sealed` to internal classes in `GeoLocator` (CA1852)
- Fix static analysis warnings in `WeatherTrend` and `MusicalInstrument`

## Verification
- `dotnet build` succeeds with zero warnings treated as errors.
- `dotnet test` passes.
