### PR TITLE
fix(weathertrend): blank chart in published builds

### DIFF
--- a/.github/workflows/release_demos.yml
+++ b/.github/workflows/release_demos.yml
@@ -33,6 +33,7 @@ jobs:
             --self-contained true `
             -p:PublishSingleFile=true `
             -p:IncludeNativeLibrariesForSelfExtract=true `
+            -p:IncludeAllContentForSelfExtract=true `
             --output release/${{ matrix.app }}
 
       - name: Zip Executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.1] - 2026-02-19
+
+### Fixed
+- **WeatherTrend:** Fixed blank chart in published builds by removing conflicting `UnitWidth` and `MinStep` axis properties (#63).
+- **WeatherTrend:** Fixed date format typo in X-axis labels (`MM:dd` → `MM-dd`).
+- **CI/CD:** Added `IncludeAllContentForSelfExtract` to single-file publish for reliable SkiaSharp native library bundling.
+
 ## [v1.2.0] - 2026-02-19
 
 ### Added

--- a/src/WeatherTrend/MainWindow.xaml.cs
+++ b/src/WeatherTrend/MainWindow.xaml.cs
@@ -83,9 +83,7 @@ namespace DotNetLearningLab.WeatherTrend
             {
                 new Axis
                 {
-                    Labeler = value => new DateTime((long)value).ToString("yyyy-MM:dd HH:mm", System.Globalization.CultureInfo.InvariantCulture),
-                    UnitWidth = TimeSpan.FromHours(1).Ticks, 
-                    MinStep = TimeSpan.FromHours(1).Ticks
+                    Labeler = value => new DateTime((long)value).ToString("yyyy-MM-dd HH:mm", System.Globalization.CultureInfo.InvariantCulture)
                 }
             };
 


### PR DESCRIPTION
Fixes #63

## Changes
- **`MainWindow.xaml.cs`**: Removed `UnitWidth` and `MinStep` from XAxes configuration. These properties conflicted with LiveCharts2's auto-scaling when using `DateTime.Ticks`, causing the chart to render an empty viewport. Also fixed date format typo (`MM:dd` → `MM-dd`).
- **`release_demos.yml`**: Added `-p:IncludeAllContentForSelfExtract=true` to ensure SkiaSharp native libraries are reliably bundled in single-file builds.
- **`CHANGELOG.md`**: Added v1.2.1 hotfix release notes.

## Verification
- **Local Publish**: Built single-file `.exe` with `dotnet publish` using identical flags to the release workflow.
- **Manual Test**: Confirmed chart renders correctly with barometric pressure data in the published build.
